### PR TITLE
Adding .vscode to ignore and custom fuse fix for PIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ dkms.conf
 *.bak
 ESPControllerCircuit/fp-info-cache
 ESPControllerCircuit/fp-info-cache
+
+**/.vscode

--- a/ATTINYCellModule/platformio.ini
+++ b/ATTINYCellModule/platformio.ini
@@ -24,16 +24,16 @@ lib_deps =
 
 upload_protocol = usbasp
 
+; efuse = 1111 1110 = Enables SPM instruction
+; hfuse = 1101 0110 = EESAVE & 1.8V BOD detection level
+; lfuse = 1110 0010 = CKDIV8 & Calibrated Internal 8MHz Oscillator
+board_fuses.lfuse = 0b11100010
+board_fuses.hfuse = 0b11010110
+board_fuses.efuse = 0b11111110
+
 ; each flag in a new line
 ;-B16 option needed for my USBASP programmer to slow it down!
 upload_flags =
   -vv
   -B16
   -Pusb
-  -Uefuse:w:0b11111110:m
-  -Uhfuse:w:0b11010110:m
-  -Ulfuse:w:0b11100010:m
-
-; efuse = 1111 1110 = Enables SPM instruction
-; hfuse = 1101 0110 = EESAVE & 1.8V BOD detection level
-; lfuse = 1110 0010 = CKDIV8 & Calibrated Internal 8MHz Oscillator

--- a/ATTINYCellModuleTestPrg/platformio.ini
+++ b/ATTINYCellModuleTestPrg/platformio.ini
@@ -20,16 +20,16 @@ lib_deps =
 
 upload_protocol = usbasp
 
+; efuse = 1111 1110 = Enables SPM instruction
+; hfuse = 1101 0110 = EESAVE & 1.8V BOD detection level
+; lfuse = 1110 0010 = CKDIV8 & Calibrated Internal 8MHz Oscillator
+board_fuses.lfuse = 0b11100010
+board_fuses.hfuse = 0b11010110
+board_fuses.efuse = 0b11111110
+
 ; each flag in a new line
 ;-B16 option needed for my USBASP programmer to slow it down!
 upload_flags =
   -vv
   -B16
   -Pusb
-  -Uefuse:w:0b11111110:m
-  -Uhfuse:w:0b11010110:m
-  -Ulfuse:w:0b11100010:m
-
-; efuse = 1111 1110 = Enables SPM instruction
-; hfuse = 1101 0110 = EESAVE & 1.8V BOD detection level
-; lfuse = 1110 0010 = CKDIV8 & Calibrated Internal 8MHz Oscillator


### PR DESCRIPTION
The latest versions of PIO pass extra fuse values by default to avrdude when programming so rather than override the fuse values via upload_flags moved them to the board_fuses approach documented [here](http://docs.platformio.org/en/latest/platforms/atmelavr.html#custom-fuses).

Also added the .vscode directories to the default exclude list, the .pio directory should also likely be added but it wasn't showing as dirty so opted to skip it.