### PR TITLE
V490 README describes a voltage reference that is not on the board

### DIFF
--- a/ModuleV490-AllInOne/README.md
+++ b/ModuleV490-AllInOne/README.md
@@ -36,35 +36,13 @@ when registering for the first time.
 
 Before construction of the PCB you must determine what battery cells you wish to monitor and a suitable cell voltage range.
 
-The PCB design has options for two voltage ranges, determined by parts U2 and U6.  *ONLY ONE OF THESE CHIPS MUST BE FITTED*
-
 The design uses a MAX14921 chip, this has a maximum of 16 cells and **65V** total battery voltage - do not exceed.
-
-## LIFEPO4 cells up to 4.00V maximum
-
-Use part U2, a Microchip voltage reference "MCP1501-40E/SN".  This is a 4.096V ±0.1% reference chip.
-
-This part is available on JLCPCB as part number C1575589.
-
-The pick and place file (CPL file) contains the part placement for this chip by default.  No further changes are required, except to double-check the order screens from JLCPCB.
-
-Do not install part U6.
-
-*This option has been tested by the author as working*
 
 ## Cell voltages up to 4.50V maximum
 
-This is all 18650 style cell voltage chemistry - normally with a maximum of 4.25V.  This configuration can also be used with LIFEPO4 cells with voltages below 4.50V.
+This is all 18650 style cell voltage chemistry - normally with a maximum of 4.25V.  It can also be used with LIFEPO4 cells, which are well below 4.50V.
 
-Use part U6, a Microchip voltage reference "MCP1502T-45E/CHY".   This is a 4.500V ±0.1% reference chip.
-
-This part is NOT available from JLCPCB.  This part must be obtained from [other sources](https://www.digikey.co.uk/en/products/detail/microchip-technology/MCP1502T-45E-CHY/16549208) and **MANUALLY** soldered onto the board.  Note this is a very small chip (SOT-23-6) and difficult to solder.
-
-Edit the pick and place (CPL file) before upload to JLCPCB to remove the line marked "U2".
-
-Do not install part U2.
-
-*This option has NOT been tested by the author, please feedback if you decide to experiment*
+The voltage reference is part U6, a Microchip "MCP1502T-45E/CHY" - a 4.500V ±0.1% reference chip, JLCPCB part number C5236158.  It is included in the bill of materials and the pick and place file (CPL file), so it is fitted along with the rest of the board.
 
 ## BATTERY VOLTAGES ABOVE 24V & MINIMUM BELOW 12V
 
@@ -140,6 +118,6 @@ Important:
 
 # FAULT FINDING
 
-## All cells read similar voltage (4.096V or 4.500V)
+## All cells read similar voltage (4.500V)
 
-This indicates that the voltage reference is not reaching the ADC chip MCP33151.  Therefore, check voltage on TP5 and also soldering around U3 and U2/U6 depending on the V reference fitted.
+This indicates that the voltage reference is not reaching the ADC chip MCP33151.  Therefore, check voltage on TP5 and also soldering around U3 and U6.


### PR DESCRIPTION
The "READ THIS FIRST" section presents U2 and U6 as a choice of voltage
reference, one of which must be fitted. U2 is not in the design:

  grep -c '"U2"'   Module_16S.kicad_sch / PowerSupply.kicad_sch / STM32.kicad_sch  -> 0 / 0 / 0
  grep -c '"U2"'   Module_16S.kicad_pcb                                           -> 0
  grep -c 'MCP1501' any of the above, plus the BOM and CPL                        -> 0
  symbol libraries: mcp1502t-45e.kicad_sym  (no MCP1501 equivalent)

It went with the "All in one revision" work squashed into master as 26c335a
(2025-04-18), which also deleted the TEST_4096 test point and left U6 =
MCP1502T-45E/CHY (4.500V) as the only reference. This was reported in
stuartpittaway/diyBMSv4#200 - the reporter noticed the footprint for U6 is
SOT-23-6 while the part named for U2 is SOIC-8, so they cannot be alternatives
for one position.

The U6 section is out of date in the other direction. It says the part is not
available from JLCPCB and has to be soldered by hand, and that the CPL needs
editing to remove U2. Neither is true of the current files:

  Module_16S_bom_jlc.csv:  "MCP1502T-45E/CHY","U6","SOT-23-6","C5236158"
  Module_16S_cpl_jlc.csv:  "U6",165.8112,-112.1156,top,180.0000

So U6 is ordered and placed with everything else, and there is no U2 line to
remove.

This removes the U2 section, drops the "one of these must be fitted" framing,
rewrites the U6 paragraph to describe what is actually on the board, and fixes
the fault finding entry that still offered 4.096V as a possible reading.

I also dropped the "*This option has NOT been tested by the author*" line from
the U6 section rather than moving it. It was written when U6 was the
alternative to U2, so "this option" no longer refers to anything now that it is
the only reference. I have not replaced it with a tested or untested statement
either way - that is yours to make, and the board-level warning at the top of
the file still stands.
